### PR TITLE
Shift equipment status to backend

### DIFF
--- a/src/components/gear-guardian/add-equipment-sheet.tsx
+++ b/src/components/gear-guardian/add-equipment-sheet.tsx
@@ -35,7 +35,10 @@ import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 
 interface EquipmentSheetProps {
-  onSave: (equipment: Omit<Equipment, 'id' | 'userId'>, id?: string) => void;
+  onSave: (
+    equipment: Omit<Equipment, 'id' | 'userId' | 'status' | 'percentageUsed'>,
+    id?: string,
+  ) => void;
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
   initialData?: Equipment | null;
@@ -162,7 +165,7 @@ export function EquipmentSheet({ onSave, isOpen, onOpenChange, initialData, isLo
       }
     }
 
-    const newEquipment: Omit<Equipment, 'id' | 'userId'> = {
+    const newEquipment: Omit<Equipment, 'id' | 'userId' | 'status' | 'percentageUsed'> = {
       name: data.name,
       type: data.type,
       serialNumber: data.serialNumber || '',

--- a/src/components/gear-guardian/dashboard.tsx
+++ b/src/components/gear-guardian/dashboard.tsx
@@ -106,7 +106,10 @@ export function Dashboard() {
     fetchEquipment();
   }, [fetchEquipment]);
 
-  const handleSaveEquipment = async (item: Omit<Equipment, 'id' | 'userId'>, id?: string) => {
+  const handleSaveEquipment = async (
+    item: Omit<Equipment, 'id' | 'userId' | 'status' | 'percentageUsed'>,
+    id?: string,
+  ) => {
     setIsLoadingData(true);
     try {
       await saveEquipment(item, id);

--- a/src/components/gear-guardian/equipment-card.tsx
+++ b/src/components/gear-guardian/equipment-card.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
-import type { Equipment } from '@/lib/types';
+import type { Equipment, EquipmentStatus } from '@/lib/types';
 import { CalendarDays, ShieldCheck, ShieldAlert, ShieldQuestion, MoreHorizontal, Pencil, Trash2, Archive, BrainCircuit } from 'lucide-react';
 import {
     Tooltip,
@@ -25,47 +25,39 @@ interface EquipmentCardProps {
 }
 
 export function EquipmentCard({ equipment, viewMode, onEdit, onDelete, onAnalyze }: EquipmentCardProps) {
-  const { serviceStartDate, expectedEndOfLife, archived, purchaseDate } = equipment;
-  
-  const now = Date.now();
-  const startTime = new Date(serviceStartDate).getTime();
-  const endTime = new Date(expectedEndOfLife).getTime();
-  const isExpired = now > endTime;
-  const totalLifespan = endTime - startTime;
-  const timeElapsed = now - startTime;
-  const percentageUsed = totalLifespan > 0 ? Math.min(100, (timeElapsed / totalLifespan) * 100) : 0;
+  const { expectedEndOfLife, archived, purchaseDate, percentageUsed, status: equipmentStatus } = equipment;
 
   const getStatus = () => {
-    if (archived) {
-      return {
-        text: 'Archivé',
-        variant: 'outline',
-        Icon: Archive,
-        progressClass: 'bg-gray-400',
-      } as const;
+    switch (equipmentStatus) {
+      case EquipmentStatus.ARCHIVED:
+        return {
+          text: 'Archivé',
+          variant: 'outline',
+          Icon: Archive,
+          progressClass: 'bg-gray-400',
+        } as const;
+      case EquipmentStatus.EXPIRED:
+        return {
+          text: 'Expiré',
+          variant: 'destructive',
+          Icon: ShieldAlert,
+          progressClass: 'bg-destructive',
+        } as const;
+      case EquipmentStatus.EXPIRING_SOON:
+        return {
+          text: 'Expire bientôt',
+          variant: 'secondary',
+          Icon: ShieldQuestion,
+          progressClass: 'bg-yellow-500',
+        } as const;
+      default:
+        return {
+          text: 'Bon état',
+          variant: 'default',
+          Icon: ShieldCheck,
+          progressClass: 'bg-primary',
+        } as const;
     }
-    if (isExpired) {
-      return {
-        text: 'Expiré',
-        variant: 'destructive',
-        Icon: ShieldAlert,
-        progressClass: 'bg-destructive',
-      } as const;
-    }
-    if (percentageUsed >= 80) {
-      return {
-        text: 'Expire bientôt',
-        variant: 'secondary',
-        Icon: ShieldQuestion,
-        progressClass: 'bg-yellow-500',
-      } as const;
-    }
-    return {
-      text: 'Bon état',
-      variant: 'default',
-      Icon: ShieldCheck,
-      progressClass: 'bg-primary',
-    } as const;
   };
 
   const status = getStatus();

--- a/src/components/gear-guardian/expiration-banner.tsx
+++ b/src/components/gear-guardian/expiration-banner.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
-import type { Equipment } from '@/lib/types';
+import type { Equipment, EquipmentStatus } from '@/lib/types';
 import { X } from 'lucide-react';
 
 interface ExpirationBannerProps {
@@ -18,14 +18,8 @@ export function ExpirationBanner({ equipment, threshold = 80 }: ExpirationBanner
   const expiringSoon = React.useMemo(() => {
     return equipment.filter(item => {
       if (item.archived) return false;
-      const now = Date.now();
-      const startTime = new Date(item.serviceStartDate).getTime();
-      const endTime = new Date(item.expectedEndOfLife).getTime();
-      if (now > endTime) return false; // already expired
-      const totalLifespan = endTime - startTime;
-      const timeElapsed = now - startTime;
-      const percentageUsed = totalLifespan > 0 ? Math.min(100, (timeElapsed / totalLifespan) * 100) : 0;
-      return percentageUsed >= threshold;
+      if (item.status === EquipmentStatus.EXPIRED) return false;
+      return item.percentageUsed >= threshold;
     });
   }, [equipment, threshold]);
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -43,7 +43,10 @@ export async function getEquipmentList() {
   return data;
 }
 
-export async function saveEquipment(equipment: Omit<Equipment, 'id' | 'userId'>, id?: string) {
+export async function saveEquipment(
+  equipment: Omit<Equipment, 'id' | 'userId' | 'status' | 'percentageUsed'>,
+  id?: string,
+) {
   if (id) {
     await api.put(`/equipment/${id}`, equipment);
   } else {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,6 +8,13 @@ export enum EquipmentType {
   OTHER = 'Autre',
 }
 
+export enum EquipmentStatus {
+  GOOD = 'GOOD',
+  EXPIRING_SOON = 'EXPIRING_SOON',
+  EXPIRED = 'EXPIRED',
+  ARCHIVED = 'ARCHIVED',
+}
+
 export interface Equipment {
   id: string;
   userId: string;
@@ -22,6 +29,8 @@ export interface Equipment {
   description: string;
   manufacturerData: string;
   archived: boolean;
+  percentageUsed: number;
+  status: EquipmentStatus;
 }
 
 export interface UserProfile {


### PR DESCRIPTION
## Summary
- extend `Equipment` model with `status` and `percentageUsed`
- fetch these fields in the API layer
- refactor UI components to display backend status
- adjust saving helpers to ignore computed fields

## Testing
- `npm run typecheck` *(fails: Cannot find module)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e954689bc83319bcba41e1e7edff6