### PR TITLE
Use alert threshold from user profile

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -37,6 +37,9 @@ export default function ProfilePage() {
     getProfile()
       .then((data) => {
         setProfile(data);
+        if (data.alertThreshold !== undefined) {
+          setNotificationThreshold(data.alertThreshold);
+        }
         setIsLoading(false);
       })
       .catch(() => {
@@ -77,14 +80,19 @@ export default function ProfilePage() {
     });
   };
 
-  const handleNotificationSave = (e: React.FormEvent) => {
+  const handleNotificationSave = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!profile) return;
-    // In a real app, you would save these preferences to the user's document on the server.
-    toast({
-      title: "Préférences enregistrées",
-      description: "Vos paramètres de notification ont été mis à jour.",
-    });
+    try {
+      const updated = await updateProfile({ alertThreshold: notificationThreshold });
+      setProfile(updated);
+      toast({
+        title: "Préférences enregistrées",
+        description: "Vos paramètres de notification ont été mis à jour.",
+      });
+    } catch (error) {
+      toast({ variant: 'destructive', title: "Erreur", description: "La mise à jour a échoué." });
+    }
   };
 
   if (isLoading || !profile) {

--- a/src/components/gear-guardian/dashboard.tsx
+++ b/src/components/gear-guardian/dashboard.tsx
@@ -50,7 +50,7 @@ import { ModeToggle } from '../mode-toggle';
 import { cn } from '@/lib/utils';
 import { buttonVariants } from '../ui/button';
 import { ExpirationBanner } from './expiration-banner';
-import { getEquipmentList, saveEquipment, deleteEquipment, logout } from '@/lib/api';
+import { getEquipmentList, saveEquipment, deleteEquipment, logout, getProfile } from '@/lib/api';
 import { useToast } from '@/hooks/use-toast';
 import { Skeleton } from '../ui/skeleton';
 
@@ -73,6 +73,9 @@ export function Dashboard() {
   const [itemToDelete, setItemToDelete] = React.useState<string | null>(null);
   const [searchQuery, setSearchQuery] = React.useState('');
 
+  // User preference for expiration alerts
+  const [alertThreshold, setAlertThreshold] = React.useState(80);
+
   const [isHealthDialogOpen, setIsHealthDialogOpen] = React.useState(false);
   const [itemToAnalyze, setItemToAnalyze] = React.useState<Equipment | null>(null);
 
@@ -80,9 +83,18 @@ export function Dashboard() {
     const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
     if (!token) {
       router.push('/');
-    } else {
-      setIsLoadingUser(false);
+      return;
     }
+    getProfile()
+      .then((profile) => {
+        if (profile.alertThreshold !== undefined) {
+          setAlertThreshold(profile.alertThreshold);
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to fetch profile', err);
+      })
+      .finally(() => setIsLoadingUser(false));
   }, [router]);
 
   const fetchEquipment = React.useCallback(async () => {
@@ -325,7 +337,7 @@ export function Dashboard() {
           </DropdownMenu>
         </header>
         <main className="flex flex-1 flex-col gap-4 p-4 lg:gap-6 lg:p-6">
-          <ExpirationBanner equipment={equipment} />
+          <ExpirationBanner equipment={equipment} threshold={alertThreshold} />
           {activeView === 'equipment' ? (
             <>
               <div className="flex items-center justify-between">

--- a/src/components/gear-guardian/expiration-banner.tsx
+++ b/src/components/gear-guardian/expiration-banner.tsx
@@ -8,7 +8,7 @@ import { X } from 'lucide-react';
 
 interface ExpirationBannerProps {
   equipment: Equipment[];
-  // TODO: This threshold should come from user profile settings
+  /** Alert threshold percentage from user profile */
   threshold?: number;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -27,4 +27,6 @@ export interface Equipment {
 export interface UserProfile {
   name: string;
   email: string;
+  /** Percentage of lifespan used before showing alerts */
+  alertThreshold?: number;
 }


### PR DESCRIPTION
## Summary
- extend `UserProfile` with `alertThreshold`
- load user's alert threshold in the profile page
- save alert threshold updates
- fetch profile in dashboard to pass alert threshold to `ExpirationBanner`
- document threshold prop in `ExpirationBanner`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685e954d4a888331a0f96b195a1ea2ff