### PR TITLE
Add photo upload API helpers

### DIFF
--- a/src/lib/api/uploadPhoto.ts
+++ b/src/lib/api/uploadPhoto.ts
@@ -1,0 +1,21 @@
+import { api } from './client';
+
+/** Upload a photo for the given EPI */
+export async function uploadPhoto(epiId: number | string, file: File) {
+  const formData = new FormData();
+  formData.append('file', file);
+  const { data } = await api.post(`/epi/${epiId}/photos`, formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+  return data;
+}
+
+/** Replace an existing EPI photo */
+export async function replacePhoto(epiId: number | string, photoId: number | string, file: File) {
+  const formData = new FormData();
+  formData.append('file', file);
+  const { data } = await api.put(`/epi/${epiId}/photos/${photoId}`, formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+  return data;
+}


### PR DESCRIPTION
## Summary
- add `uploadPhoto` and `replacePhoto` API helpers using `FormData`

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717a861ed48331b86c229cd7d9c3da