### PR TITLE
Fix onRefresh callback in equipment sheet

### DIFF
--- a/src/components/gear-guardian/add-equipment-sheet.tsx
+++ b/src/components/gear-guardian/add-equipment-sheet.tsx
@@ -33,7 +33,6 @@ import {
 } from '@/components/ui/sheet';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
-import {onRefresh} from "next/dist/client/components/react-dev-overlay/pages/client";
 
 interface EquipmentSheetProps {
   onSave: (
@@ -63,7 +62,7 @@ const equipmentFormSchema = z.object({
 
 type EquipmentFormValues = z.infer<typeof equipmentFormSchema>;
 
-export function EquipmentSheet({ onSave, isOpen, onOpenChange, initialData, isLoading }: EquipmentSheetProps) {
+export function EquipmentSheet({ onSave, isOpen, onOpenChange, initialData, isLoading, onRefresh }: EquipmentSheetProps) {
   const isEditMode = !!initialData;
 
   const validationSchema = React.useMemo(() => {
@@ -179,7 +178,7 @@ export function EquipmentSheet({ onSave, isOpen, onOpenChange, initialData, isLo
       }
     }
 
-
+    onRefresh?.();
     onOpenChange(false); // ferme le sheet
   };
 


### PR DESCRIPTION
## Summary
- remove erroneous import of `onRefresh`
- pass `onRefresh` prop to `EquipmentSheet`
- call `onRefresh` after saving equipment

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717a8683ac833189851c34c87c1556