### PR TITLE
Remove unused onRefresh import

### DIFF
--- a/src/components/gear-guardian/add-equipment-sheet.tsx
+++ b/src/components/gear-guardian/add-equipment-sheet.tsx
@@ -33,7 +33,6 @@ import {
 } from '@/components/ui/sheet';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
-import {onRefresh} from "next/dist/client/components/react-dev-overlay/pages/client";
 
 interface EquipmentSheetProps {
   onSave: (


### PR DESCRIPTION
## Summary
- clean up unused `onRefresh` import in AddEquipmentSheet

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717a8546cc8331aade6518c597d9ba